### PR TITLE
:green_heart: Disabled aws secret retrieval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ workflows:
                 - main
       - hmpps/deploy_env:
           name: deploy_dev
+          retrieve_secrets: none
           env: "dev"
           context: hmpps-common-vars
           filters:
@@ -58,6 +59,7 @@ workflows:
             - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod
+          retrieve_secrets: none
           env: "preprod"
           context:
             - hmpps-common-vars
@@ -70,6 +72,7 @@ workflows:
             - deploy_preprod
       - hmpps/deploy_env:
           name: deploy_prod
+          retrieve_secrets: none
           env: "prod"
           slack_notification: true
           context:

--- a/helm_deploy/hmpps-user-preferences/templates/secrets.yaml
+++ b/helm_deploy/hmpps-user-preferences/templates/secrets.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "app.name" . }}
-  labels:
-    {{- include "app.labels" . | nindent 4 }}
-type: Opaque
-data:
-{{/*  APPINSIGHTS_INSTRUMENTATIONKEY: {{ .Values.secrets.APPINSIGHTS_INSTRUMENTATIONKEY | b64enc | quote }}*/}}


### PR DESCRIPTION
We have decided to **not** use AWS secrets manager for our secrets and will use k8s secrets instead like our other api's,so this should disable the secret retrieval step from the build.