### PR TITLE
:wrench: add slack channel name so notifications go to probation-in-c…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ workflows:
           name: deploy_prod
           retrieve_secrets: none
           env: "prod"
+          slack_channel_name: probation-in-court-dev
           slack_notification: true
           context:
             - hmpps-common-vars


### PR DESCRIPTION
…ourt-dev

This PR adds `slack-channel-name` to the circle deploy prod build, by default notifications go to `dps_releases` slack channel so this will mean the notifications will instead go to `probation_in_court_dev`.