### PR TITLE
:arrow_up: Upgrade gradle-spring-boot for security

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "2.1.0"
-  kotlin("plugin.spring") version "1.4.21"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.1"
+  kotlin("plugin.spring") version "1.4.10"
+  id("org.jetbrains.kotlin.plugin.jpa") version "1.4.20"
 }
 
 configurations {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,3 @@
-spring:
-  profiles:
-    include: stdout
-
 server:
   shutdown: immediate
 


### PR DESCRIPTION
Upgrading to a version of Spring Boot that pulls in
`tomcat-embed-core:9.0.43` to fix security issues highlighted in snyk.

Full path:
```
|    +--- org.springframework.boot:spring-boot-starter-tomcat:2.4.3
|    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.43
```