### PR TITLE
Fix remove ingress from dev testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,17 +27,5 @@ services:
     volumes:
       - ./src/main/resources/db/local/init:/docker-entrypoint-initdb.d:ro
 
-  ingress:
-    image: nginx:1.27-alpine
-    container_name: ingress
-    networks:
-      - hmpps
-    ports:
-      - "80:80"
-    depends_on:
-      - hmpps-auth
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-
 networks:
   hmpps:


### PR DESCRIPTION
Removing the ingress I added to help with testing, to hopefully fix the build error:

`Error: release hmpps-user-preferences failed, and has been uninstalled due to rollback-on-failure being set: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "hmpps-user-preferences-dev.hmpps.service.justice.gov.uk" and path "/" is already defined in ingress hmpps-user-preferences-dev/hmpps-user-preferences`